### PR TITLE
Adjust DB_HOSTNAME for ORDS in Dockerfile

### DIFF
--- a/ords/ol7_ords/Dockerfile
+++ b/ords/ol7_ords/Dockerfile
@@ -58,7 +58,7 @@ ENV JAVA_SOFTWARE="OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz"          \
 
 # ------------------------------------------------------------------------------
 # Define config (runtime) environment variables.
-ENV DB_HOSTNAME="ol7-183.localdomain"                                          \
+ENV DB_HOSTNAME="db"                                          \
     DB_PORT="1521"                                                             \
     DB_SERVICE="pdb1"                                                          \
     APEX_PUBLIC_USER_PASSWORD="ApexPassword1"                                  \

--- a/ords/ol8_ords/Dockerfile
+++ b/ords/ol8_ords/Dockerfile
@@ -59,7 +59,7 @@ ENV JAVA_SOFTWARE="OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz"          \
 
 # ------------------------------------------------------------------------------
 # Define config (runtime) environment variables.
-ENV DB_HOSTNAME="ol8-19.localdomain"                                           \
+ENV DB_HOSTNAME="db"                                           \
     DB_PORT="1521"                                                             \
     DB_SERVICE="pdb1"                                                          \
     APEX_PUBLIC_USER_PASSWORD="ApexPassword1"                                  \


### PR DESCRIPTION
Adjust DB_HOSTNAME to match service-name in docker-compose-file, so ORDS can connect to DB and make it compatible with docker-compose-file