### PR TITLE
variables for docker_fg_id, tomcat_user_id and oracle_user_id

### DIFF
--- a/database/ol7_121/Dockerfile
+++ b/database/ol7_121/Dockerfile
@@ -62,8 +62,9 @@ ENV ORACLE_SID="cdb1"                                                          \
     INSTALL_APEX="true"                                                        \
     PDB_PASSWORD="PdbPassword1"                                                \
     APEX_EMAIL="me@example.com"                                                \
-    APEX_PASSWORD="ApexPassword1"                                              \
-    DOCKER_FG_ID="1042"
+    APEX_PASSWORD="ApexPassword1"                                              \\
+    DOCKER_FG_ID="1042"                                                        \
+    ORACLE_USER_ID="500"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -81,7 +82,7 @@ COPY scripts/* ${SCRIPTS_DIR}/
 RUN groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
     groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
-    useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
+    useradd -d /home/oracle -u ${ORACLE_USER_ID} -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     yum -y install unzip tar gzip                                           && \
     yum -y update                                                           && \
     yum -y install oracle-rdbms-server-12cR1-preinstall                     && \

--- a/database/ol7_121/Dockerfile
+++ b/database/ol7_121/Dockerfile
@@ -62,7 +62,7 @@ ENV ORACLE_SID="cdb1"                                                          \
     INSTALL_APEX="true"                                                        \
     PDB_PASSWORD="PdbPassword1"                                                \
     APEX_EMAIL="me@example.com"                                                \
-    APEX_PASSWORD="ApexPassword1"                                              \\
+    APEX_PASSWORD="ApexPassword1"                                              \
     DOCKER_FG_ID="1042"                                                        \
     ORACLE_USER_ID="500"
 

--- a/database/ol7_121/Dockerfile
+++ b/database/ol7_121/Dockerfile
@@ -62,7 +62,8 @@ ENV ORACLE_SID="cdb1"                                                          \
     INSTALL_APEX="true"                                                        \
     PDB_PASSWORD="PdbPassword1"                                                \
     APEX_EMAIL="me@example.com"                                                \
-    APEX_PASSWORD="ApexPassword1"
+    APEX_PASSWORD="ApexPassword1"                                              \
+    DOCKER_FG_ID="1042"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -79,7 +80,7 @@ COPY scripts/* ${SCRIPTS_DIR}/
 #
 RUN groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
-    groupadd -g 1042 docker_fg                                              && \
+    groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
     useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     yum -y install unzip tar gzip                                           && \
     yum -y update                                                           && \

--- a/database/ol7_122/Dockerfile
+++ b/database/ol7_122/Dockerfile
@@ -62,7 +62,8 @@ ENV ORACLE_SID=cdb1                                                            \
     PDB_PASSWORD="PdbPassword1"                                                \
     INSTALL_APEX="true"                                                        \
     APEX_EMAIL="me@example.com"                                                \
-    APEX_PASSWORD="ApexPassword1"
+    APEX_PASSWORD="ApexPassword1"                                              \
+    DOCKER_FG_ID="1042"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -79,7 +80,7 @@ COPY scripts/* ${SCRIPTS_DIR}/
 #
 RUN groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
-    groupadd -g 1042 docker_fg                                              && \
+    groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
     useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     yum -y install unzip tar gzip                                           && \
     yum -y update                                                           && \

--- a/database/ol7_122/Dockerfile
+++ b/database/ol7_122/Dockerfile
@@ -63,7 +63,8 @@ ENV ORACLE_SID=cdb1                                                            \
     INSTALL_APEX="true"                                                        \
     APEX_EMAIL="me@example.com"                                                \
     APEX_PASSWORD="ApexPassword1"                                              \
-    DOCKER_FG_ID="1042"
+    DOCKER_FG_ID="1042"                                                        \
+    ORACLE_USER_ID="500"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -81,7 +82,7 @@ COPY scripts/* ${SCRIPTS_DIR}/
 RUN groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
     groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
-    useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
+    useradd -d /home/oracle -u ${ORACLE_USER_ID} -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     yum -y install unzip tar gzip                                           && \
     yum -y update                                                           && \
     yum -y install oracle-database-server-12cR2-preinstall                  && \

--- a/database/ol7_183/Dockerfile
+++ b/database/ol7_183/Dockerfile
@@ -62,7 +62,8 @@ ENV ORACLE_SID=cdb1                                                            \
     PDB_PASSWORD="PdbPassword1"                                                \
     INSTALL_APEX="true"                                                        \
     APEX_EMAIL="me@example.com"                                                \
-    APEX_PASSWORD="ApexPassword1"
+    APEX_PASSWORD="ApexPassword1"                                              \
+    DOCKER_FG_ID="1042"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -79,7 +80,7 @@ COPY scripts/* ${SCRIPTS_DIR}/
 #
 RUN groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
-    groupadd -g 1042 docker_fg                                              && \
+    groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
     useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     yum -y install unzip tar gzip                                           && \
     yum -y update                                                           && \

--- a/database/ol7_183/Dockerfile
+++ b/database/ol7_183/Dockerfile
@@ -63,7 +63,8 @@ ENV ORACLE_SID=cdb1                                                            \
     INSTALL_APEX="true"                                                        \
     APEX_EMAIL="me@example.com"                                                \
     APEX_PASSWORD="ApexPassword1"                                              \
-    DOCKER_FG_ID="1042"
+    DOCKER_FG_ID="1042"                                                        \
+    ORACLE_USER_ID="500"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -81,7 +82,7 @@ COPY scripts/* ${SCRIPTS_DIR}/
 RUN groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
     groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
-    useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
+    useradd -d /home/oracle -u ${ORACLE_USER_ID} -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     yum -y install unzip tar gzip                                           && \
     yum -y update                                                           && \
     yum -y install oracle-database-preinstall-18c                           && \

--- a/database/ol7_19/Dockerfile
+++ b/database/ol7_19/Dockerfile
@@ -65,7 +65,7 @@ ENV ORACLE_SID=cdb1                                                            \
     INSTALL_APEX="true"                                                        \
     APEX_EMAIL="me@example.com"                                                \
     APEX_PASSWORD="ApexPassword1"                                              \
-    DOCKER_FG_ID="3333"
+    DOCKER_FG_ID="1042
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.

--- a/database/ol7_19/Dockerfile
+++ b/database/ol7_19/Dockerfile
@@ -64,7 +64,8 @@ ENV ORACLE_SID=cdb1                                                            \
     PDB_PASSWORD="PdbPassword1"                                                \
     INSTALL_APEX="true"                                                        \
     APEX_EMAIL="me@example.com"                                                \
-    APEX_PASSWORD="ApexPassword1"
+    APEX_PASSWORD="ApexPassword1"                                              \
+    DOCKER_FG_ID="3333"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -81,7 +82,7 @@ COPY scripts/* ${SCRIPTS_DIR}/
 #
 RUN groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
-    groupadd -g 1042 docker_fg                                              && \
+    groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
     useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     yum -y install unzip tar gzip                                           && \
     yum -y update                                                           && \

--- a/database/ol7_19/Dockerfile
+++ b/database/ol7_19/Dockerfile
@@ -66,7 +66,7 @@ ENV ORACLE_SID=cdb1                                                            \
     APEX_EMAIL="me@example.com"                                                \
     APEX_PASSWORD="ApexPassword1"                                              \
     DOCKER_FG_ID="1042"                                                        \
-    DOCKER_FG_ID="500"
+    ORACLE_USER_ID="500"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.

--- a/database/ol7_19/Dockerfile
+++ b/database/ol7_19/Dockerfile
@@ -65,7 +65,8 @@ ENV ORACLE_SID=cdb1                                                            \
     INSTALL_APEX="true"                                                        \
     APEX_EMAIL="me@example.com"                                                \
     APEX_PASSWORD="ApexPassword1"                                              \
-    DOCKER_FG_ID="1042
+    DOCKER_FG_ID="1042"                                                        \
+    DOCKER_FG_ID="500"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -83,7 +84,7 @@ COPY scripts/* ${SCRIPTS_DIR}/
 RUN groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
     groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
-    useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
+    useradd -d /home/oracle -u ${ORACLE_USER_ID} -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     yum -y install unzip tar gzip                                           && \
     yum -y update                                                           && \
     yum -y install oracle-database-preinstall-19c                           && \

--- a/database/ol7_21/Dockerfile
+++ b/database/ol7_21/Dockerfile
@@ -66,7 +66,8 @@ ENV ORACLE_SID=cdb1                                                            \
     INSTALL_APEX="true"                                                        \
     APEX_EMAIL="me@example.com"                                                \
     APEX_PASSWORD="ApexPassword1"                                              \
-    DOCKER_FG_ID="1042"
+    DOCKER_FG_ID="1042"                                                        \
+    ORACLE_USER_ID="500"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -84,7 +85,7 @@ COPY scripts/* ${SCRIPTS_DIR}/
 RUN groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
     groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
-    useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
+    useradd -d /home/oracle -u ${ORACLE_USER_ID} -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     yum -y install unzip tar gzip                                           && \
     yum -y update                                                           && \
     yum -y install oracle-database-preinstall-21c                           && \

--- a/database/ol7_21/Dockerfile
+++ b/database/ol7_21/Dockerfile
@@ -65,7 +65,8 @@ ENV ORACLE_SID=cdb1                                                            \
     PDB_PASSWORD="PdbPassword1"                                                \
     INSTALL_APEX="true"                                                        \
     APEX_EMAIL="me@example.com"                                                \
-    APEX_PASSWORD="ApexPassword1"
+    APEX_PASSWORD="ApexPassword1"                                              \
+    DOCKER_FG_ID="1042"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -82,7 +83,7 @@ COPY scripts/* ${SCRIPTS_DIR}/
 #
 RUN groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
-    groupadd -g 1042 docker_fg                                              && \
+    groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
     useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     yum -y install unzip tar gzip                                           && \
     yum -y update                                                           && \

--- a/database/ol8_183/Dockerfile
+++ b/database/ol8_183/Dockerfile
@@ -63,7 +63,8 @@ ENV ORACLE_SID=cdb1                                                            \
     PDB_PASSWORD="PdbPassword1"                                                \
     INSTALL_APEX="true"                                                        \
     APEX_EMAIL="me@example.com"                                                \
-    APEX_PASSWORD="ApexPassword1"
+    APEX_PASSWORD="ApexPassword1"                                              \
+    DOCKER_FG_ID="1042"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -80,7 +81,7 @@ COPY scripts/* ${SCRIPTS_DIR}/
 #
 RUN groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
-    groupadd -g 1042 docker_fg                                              && \
+    groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
     useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     sh ${SCRIPTS_DIR}/install_os_packages.sh                                && \
     mkdir -p ${ORACLE_HOME}                                                 && \

--- a/database/ol8_183/Dockerfile
+++ b/database/ol8_183/Dockerfile
@@ -64,7 +64,8 @@ ENV ORACLE_SID=cdb1                                                            \
     INSTALL_APEX="true"                                                        \
     APEX_EMAIL="me@example.com"                                                \
     APEX_PASSWORD="ApexPassword1"                                              \
-    DOCKER_FG_ID="1042"
+    DOCKER_FG_ID="1042"                                                        \
+    ORACLE_USER_ID="500"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -82,7 +83,7 @@ COPY scripts/* ${SCRIPTS_DIR}/
 RUN groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
     groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
-    useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
+    useradd -d /home/oracle -u ${ORACLE_USER_ID} -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     sh ${SCRIPTS_DIR}/install_os_packages.sh                                && \
     mkdir -p ${ORACLE_HOME}                                                 && \
     mkdir -p /u02/oradata                                                   && \

--- a/database/ol8_19/Dockerfile
+++ b/database/ol8_19/Dockerfile
@@ -66,7 +66,8 @@ ENV ORACLE_SID=cdb1                                                            \
     INSTALL_APEX="true"                                                        \
     APEX_EMAIL="me@example.com"                                                \
     APEX_PASSWORD="ApexPassword1"                                              \
-    DOCKER_FG_ID="1042"
+    DOCKER_FG_ID="1042"                                                        \
+    ORACLE_USER_ID="500"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -85,7 +86,7 @@ RUN microdnf install -y shadow-utils                                        && \
     groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
     groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
-    useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
+    useradd -d /home/oracle -u ${ORACLE_USER_ID} -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     sh ${SCRIPTS_DIR}/install_os_packages.sh                                && \
     mkdir -p ${ORACLE_HOME}                                                 && \
     mkdir -p /u02/oradata                                                   && \

--- a/database/ol8_19/Dockerfile
+++ b/database/ol8_19/Dockerfile
@@ -65,7 +65,8 @@ ENV ORACLE_SID=cdb1                                                            \
     PDB_PASSWORD="PdbPassword1"                                                \
     INSTALL_APEX="true"                                                        \
     APEX_EMAIL="me@example.com"                                                \
-    APEX_PASSWORD="ApexPassword1"
+    APEX_PASSWORD="ApexPassword1"                                              \
+    DOCKER_FG_ID="1042"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -83,7 +84,7 @@ COPY scripts/* ${SCRIPTS_DIR}/
 RUN microdnf install -y shadow-utils                                        && \
     groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
-    groupadd -g 1042 docker_fg                                              && \
+    groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
     useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     sh ${SCRIPTS_DIR}/install_os_packages.sh                                && \
     mkdir -p ${ORACLE_HOME}                                                 && \

--- a/database/ol8_21/Dockerfile
+++ b/database/ol8_21/Dockerfile
@@ -66,7 +66,8 @@ ENV ORACLE_SID=cdb1                                                            \
     PDB_PASSWORD="PdbPassword1"                                                \
     INSTALL_APEX="true"                                                        \
     APEX_EMAIL="me@example.com"                                                \
-    APEX_PASSWORD="ApexPassword1"
+    APEX_PASSWORD="ApexPassword1"                                              \
+    DOCKER_FG_ID="1042"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -84,7 +85,7 @@ COPY scripts/* ${SCRIPTS_DIR}/
 RUN microdnf install -y shadow-utils                                        && \
     groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
-    groupadd -g 1042 docker_fg                                              && \
+    groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
     useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     sh ${SCRIPTS_DIR}/install_os_packages.sh                                && \
     mkdir -p ${ORACLE_HOME}                                                 && \

--- a/database/ol8_21/Dockerfile
+++ b/database/ol8_21/Dockerfile
@@ -67,7 +67,8 @@ ENV ORACLE_SID=cdb1                                                            \
     INSTALL_APEX="true"                                                        \
     APEX_EMAIL="me@example.com"                                                \
     APEX_PASSWORD="ApexPassword1"                                              \
-    DOCKER_FG_ID="1042"
+    DOCKER_FG_ID="1042"                                                        \
+    ORACLE_USER_ID="500"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.
@@ -86,7 +87,7 @@ RUN microdnf install -y shadow-utils                                        && \
     groupadd -g 500 dba                                                     && \
     groupadd -g 501 oinstall                                                && \
     groupadd -g ${DOCKER_FG_ID} docker_fg                                   && \
-    useradd -d /home/oracle -u 500 -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
+    useradd -d /home/oracle -u ${ORACLE_USER_ID} -g dba -G oinstall,dba,docker_fg -m -s /bin/bash oracle   && \
     sh ${SCRIPTS_DIR}/install_os_packages.sh                                && \
     mkdir -p ${ORACLE_HOME}                                                 && \
     mkdir -p /u02/oradata                                                   && \

--- a/ords/ol7_ords/Dockerfile
+++ b/ords/ol7_ords/Dockerfile
@@ -75,7 +75,7 @@ ENV DB_HOSTNAME="ol7-183.localdomain"                                          \
     AJP_ADDRESS="::1"                                                          \
     APEX_IMAGES_REFRESH="false"                                                \
     PROXY_IPS="123.123.123.123\|123.123.123.124"                               \
-    DOCKER_FG_ID="3333"
+    DOCKER_FG_ID="1042"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.

--- a/ords/ol7_ords/Dockerfile
+++ b/ords/ol7_ords/Dockerfile
@@ -56,7 +56,8 @@ ENV JAVA_SOFTWARE="OpenJDK11U-jdk_x64_linux_hotspot_11.0.14_9.tar.gz"          \
     ORDS_CONF="/u01/ords/conf"                                                 \
     JAVA_HOME="/u01/java/latest"                                               \
     CATALINA_HOME="/u01/tomcat/latest"                                         \
-    CATALINA_BASE="/u01/config/instance1"
+    CATALINA_BASE="/u01/config/instance1"                                      \
+    DOCKER_FG_ID="3333"
 
 # ------------------------------------------------------------------------------
 # Define config (runtime) environment variables.

--- a/ords/ol7_ords/Dockerfile
+++ b/ords/ol7_ords/Dockerfile
@@ -75,7 +75,8 @@ ENV DB_HOSTNAME="ol7-183.localdomain"                                          \
     AJP_ADDRESS="::1"                                                          \
     APEX_IMAGES_REFRESH="false"                                                \
     PROXY_IPS="123.123.123.123\|123.123.123.124"                               \
-    DOCKER_FG_ID="1042"
+    DOCKER_FG_ID="1042"                                                        \
+    TOMCAT_USER_ID="501"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.

--- a/ords/ol7_ords/Dockerfile
+++ b/ords/ol7_ords/Dockerfile
@@ -48,7 +48,7 @@ ENV JAVA_SOFTWARE="OpenJDK11U-jdk_x64_linux_hotspot_11.0.14_9.tar.gz"          \
     TOMCAT_SOFTWARE="apache-tomcat-9.0.56.tar.gz"                              \
     ORDS_SOFTWARE="ords-21.4.0.348.1956.zip"                                   \
     APEX_SOFTWARE="apex_21.2_en.zip"                                           \ 
-    SQLCL_SOFTWARE="sqlcl-21.4.1.17.1458.zip"                                 \
+    SQLCL_SOFTWARE="sqlcl-21.4.1.17.1458.zip"                                  \
     SOFTWARE_DIR="/u01/software"                                               \
     SCRIPTS_DIR="/u01/scripts"                                                 \
     KEYSTORE_DIR="/u01/keystore"                                               \
@@ -56,8 +56,7 @@ ENV JAVA_SOFTWARE="OpenJDK11U-jdk_x64_linux_hotspot_11.0.14_9.tar.gz"          \
     ORDS_CONF="/u01/ords/conf"                                                 \
     JAVA_HOME="/u01/java/latest"                                               \
     CATALINA_HOME="/u01/tomcat/latest"                                         \
-    CATALINA_BASE="/u01/config/instance1"                                      \
-    DOCKER_FG_ID="3333"
+    CATALINA_BASE="/u01/config/instance1"
 
 # ------------------------------------------------------------------------------
 # Define config (runtime) environment variables.
@@ -75,7 +74,8 @@ ENV DB_HOSTNAME="ol7-183.localdomain"                                          \
     AJP_SECRET="AJPSecret1"                                                    \
     AJP_ADDRESS="::1"                                                          \
     APEX_IMAGES_REFRESH="false"                                                \
-    PROXY_IPS="123.123.123.123\|123.123.123.124"
+    PROXY_IPS="123.123.123.123\|123.123.123.124"                               \
+    DOCKER_FG_ID="3333"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.

--- a/ords/ol7_ords/scripts/ords_software_installation.sh
+++ b/ords/ol7_ords/scripts/ords_software_installation.sh
@@ -2,7 +2,7 @@ echo "**************************************************************************
 echo "ORDS Software Installation." `date`
 echo "******************************************************************************"
 echo "Create docker_fg group and tomcat user."
-groupadd -g 1042 docker_fg
+groupadd -g ${DOCKER_FG_ID} docker_fg
 useradd tomcat -u 501 -G docker_fg
 
 echo "Java setup."

--- a/ords/ol7_ords/scripts/ords_software_installation.sh
+++ b/ords/ol7_ords/scripts/ords_software_installation.sh
@@ -3,7 +3,7 @@ echo "ORDS Software Installation." `date`
 echo "******************************************************************************"
 echo "Create docker_fg group and tomcat user."
 groupadd -g ${DOCKER_FG_ID} docker_fg
-useradd tomcat -u 501 -G docker_fg
+useradd tomcat -u ${TOMCAT_USER_ID} -G docker_fg
 
 echo "Java setup."
 mkdir -p /u01/java

--- a/ords/ol8_ords/Dockerfile
+++ b/ords/ol8_ords/Dockerfile
@@ -75,7 +75,8 @@ ENV DB_HOSTNAME="ol8-19.localdomain"                                           \
     AJP_SECRET="AJPSecret1"                                                    \
     AJP_ADDRESS="::1"                                                          \
     APEX_IMAGES_REFRESH="false"                                                \
-    PROXY_IPS="123.123.123.123\|123.123.123.124"
+    PROXY_IPS="123.123.123.123\|123.123.123.124"                               \
+    DOCKER_FG_ID="1042"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.

--- a/ords/ol8_ords/Dockerfile
+++ b/ords/ol8_ords/Dockerfile
@@ -76,7 +76,8 @@ ENV DB_HOSTNAME="ol8-19.localdomain"                                           \
     AJP_ADDRESS="::1"                                                          \
     APEX_IMAGES_REFRESH="false"                                                \
     PROXY_IPS="123.123.123.123\|123.123.123.124"                               \
-    DOCKER_FG_ID="1042"
+    DOCKER_FG_ID="1042"                                                        \
+    TOMCAT_USER_ID="501"
 
 # ------------------------------------------------------------------------------
 # Get all the files for the build.

--- a/ords/ol8_ords/scripts/ords_software_installation.sh
+++ b/ords/ol8_ords/scripts/ords_software_installation.sh
@@ -2,7 +2,7 @@ echo "**************************************************************************
 echo "ORDS Software Installation." `date`
 echo "******************************************************************************"
 echo "Create docker_fg group and tomcat user."
-groupadd -g 1042 docker_fg
+groupadd -g ${DOCKER_FG_ID} docker_fg
 useradd tomcat -u 501 -G docker_fg
 
 echo "Java setup."

--- a/ords/ol8_ords/scripts/ords_software_installation.sh
+++ b/ords/ol8_ords/scripts/ords_software_installation.sh
@@ -3,7 +3,7 @@ echo "ORDS Software Installation." `date`
 echo "******************************************************************************"
 echo "Create docker_fg group and tomcat user."
 groupadd -g ${DOCKER_FG_ID} docker_fg
-useradd tomcat -u 501 -G docker_fg
+useradd tomcat -u ${TOMCAT_USER_ID} -G docker_fg
 
 echo "Java setup."
 mkdir -p /u01/java


### PR DESCRIPTION
I changed your static values to variables. This allows me to change it easily. Now I can use sed to manipulate it. I can now be sure that the correct IDs are specified on the host side and in the container.

I know normally docker_fg should be sufficient/was intended for this. However, I have ready-made scripts that do the installation without intervention and this simplifies it a lot.